### PR TITLE
Exclude concat_proj files from output

### DIFF
--- a/concat_proj.py
+++ b/concat_proj.py
@@ -69,6 +69,10 @@ def get_default_ignore_patterns() -> List[str]:
         '**/*.swn',           # Vim swap files
         '**/*.bak',           # Generic backup files
         '**/*#',              # Emacs auto-save files
+
+        # Concat-proj files
+        'concat_proj.py',
+        'concat-proj/**',
     ]
 
 def should_include_file(file_path: str, include_patterns: List[str], ignore_patterns: List[str]) -> bool:


### PR DESCRIPTION
Add "concat_proj.py" and the "concat-proj" folder (in case someone clones the repo directly into their project) to the exclude list so the script never adds itself to the .txt file!